### PR TITLE
fix build script trying to tar invalid directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ main() {
 
     echo "[~] Entering build directory ..."
     cd build || echo "[!] Failed to enter build directory!"
-    tar c --file scientifica.tar scientifica ligature_plugins
+    tar c --file scientifica.tar scientifica
     echo "[~] Leaving build directory ..."
 
     echo "[!] Done!"


### PR DESCRIPTION
Before, it tried to tar `build/ligature_plugins`, which doesn't exist because the plugins were actually copied to `build/scientifica/ligature_plugins` by the `export_plugins` function